### PR TITLE
Fix backspace capture

### DIFF
--- a/keepkeylib/client.py
+++ b/keepkeylib/client.py
@@ -272,7 +272,7 @@ class TextUIMixin(object):
                 # capture spaces
                 return proto.CharacterAck(character=' ')
 
-            elif character_ascii == 127 \
+            elif character_ascii == 8 or character_ascii == 127 \
             and (msg.word_pos > 0 or msg.character_pos > 0):
                 # capture backspaces
                 return proto.CharacterAck(delete=True)


### PR DESCRIPTION
Backspace characters were not previously recognized, at least not on my system running Arch Linux.

Some systems may send a Delete character (ASCII 127) when the user presses the Backspace key, but this behavior is incorrect, or at least non-standard. The Backspace key should type a Backspace character (ASCII 8).

With this commit we retain the previous support for Delete characters, while adding identical support for actual Backspace characters.