### PR TITLE
keepkeyctl: fix Python 3 argparse error (when invoked without arguments)

### DIFF
--- a/keepkeyctl
+++ b/keepkeyctl
@@ -21,6 +21,8 @@ def parse_args(commands):
 #    parser.add_argument('-d', '--debug', dest='debug', action='store_true', help='Enable low-level debugging')
 
     cmdparser = parser.add_subparsers(title='Available commands')
+    cmdparser.required = True
+    cmdparser.dest = 'command'
 
     for cmd in commands._list_commands():
         func = object.__getattribute__(commands, cmd)


### PR DESCRIPTION
The following error happens on Python 3.4 and 3.5:
```
$ python3 keepkeyctl
Traceback (most recent call last):
  File "keepkeyctl", line 444, in <module>
    main()
  File "keepkeyctl", line 416, in main
    if args.cmd == 'list':
AttributeError: 'Namespace' object has no attribute 'cmd'
```
After the fix, the failure message should be:
```
$ python3 keepkeyctl
usage: keepkeyctl [-h] [-v] [-t {usb,serial,pipe,socket,bridge}] [-p PATH]
                  [-j]
                  {apply_policy,change_pin,clear_session,decrypt_keyvalue,decrypt_message,encrypt_keyvalue,encrypt_message,firmware_update,get_address,get_entropy,get_features,get_public_node,list,list_coins,load_device,ping,recovery_device,reset_device,set_label,sign_message,verify_message,wipe_device}
                  ...
keepkeyctl: error: the following arguments are required: command
```