### PR TITLE
fix keepkeylib imports and mixed whitespace so keepkeyctl can run

### DIFF
--- a/keepkeylib/client.py
+++ b/keepkeylib/client.py
@@ -899,7 +899,7 @@ class ProtocolMixin(object):
         if self.features.initialized:
             raise Exception("Device is initialized already. Call wipe_device() and try again.")
         if not use_trezor_method:
-			word_count = 0
+            word_count = 0
         elif word_count not in (12, 18, 24):
             raise Exception("Invalid word count. Use 12/18/24")
 

--- a/keepkeylib/messages_pb2.py
+++ b/keepkeylib/messages_pb2.py
@@ -9,7 +9,7 @@ from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 
-import types_pb2
+import keepkeylib.types_pb2 as types_pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(

--- a/keepkeylib/types_pb2.py
+++ b/keepkeylib/types_pb2.py
@@ -10,7 +10,7 @@ from google.protobuf import descriptor_pb2
 
 
 import google.protobuf.descriptor_pb2
-import exchange_pb2
+import keepkeylib.exchange_pb2 as exchange_pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(


### PR DESCRIPTION
I found it was not possible to use keepkeyctl without the following patch to fix whitespace and some broken imports.