### PR TITLE
Use find_packages instead of listing each module independently

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='keepkey',
@@ -8,27 +8,7 @@ setup(
     author_email='support@keepkey.com',
     description='Python library for communicating with KeepKey Hardware Wallet',
     url='https://github.com/keepkey/python-keepkey',
-    py_modules=[
-        'keepkeylib.ckd_public',
-        'keepkeylib.client',
-        'keepkeylib.debuglink',
-        'keepkeylib.mapping',
-        'keepkeylib.messages_pb2',
-        'keepkeylib.protobuf_json',
-        'keepkeylib.qt.pinmatrix',
-        'keepkeylib.tools',
-        'keepkeylib.transport',
-        'keepkeylib.transport_fake',
-        'keepkeylib.transport_hid',
-        'keepkeylib.transport_pipe',
-        'keepkeylib.transport_serial',
-        'keepkeylib.transport_socket',
-        'keepkeylib.transport_webusb',
-        'keepkeylib.transport_udp',
-        'keepkeylib.tx_api',
-        'keepkeylib.types_pb2',
-        'keepkeylib.exchange_pb2',
-    ],
+    packages=find_packages(exclude=['tests']),
     scripts = ['keepkeyctl'],
     test_suite='tests/**/test_*.py',
     install_requires=[


### PR DESCRIPTION
This also fixes a bug where importing `keepkeylib.client` would error with `ImportError: cannot import name 'messages_eos_pb2'` as `messages_eos_pb2` was not included in the original `py_modules` list. This will make such errors not happen as all modules and packages will be automatically detected.