### PR TITLE
Appended updated KeepKey productId to DEVICE_IDS list.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keepkey',
-    version='6.3.1',
+    version='6.3.2',
     author='TREZOR and KeepKey',
     author_email='support@keepkey.com',
     description='Python library for communicating with KeepKey Hardware Wallet',


### PR DESCRIPTION
An additional `[vendorId, productId]` element was appended to the `DEVICE_IDS` list at the top of transport_hid.py so that devices with firmware version >= 6.4.0 are detected properly. The fix has been tested on Linux and MacOS.