### PR TITLE
fead: add top evm networks

### DIFF
--- a/keepkeylib/eth/ethereum_networks.json
+++ b/keepkeylib/eth/ethereum_networks.json
@@ -90,11 +90,6 @@
         "symbol": "BNB"
     },
     {
-        "chain_id": 56,
-        "name": "BSC Smart Chain",
-        "symbol": "BNB"
-    },
-    {
         "chain_id": 57,
         "name": "Syscoin",
         "symbol": "SYS"
@@ -423,11 +418,6 @@
         "chain_id": 1313161554,
         "name": "Aurora",
         "symbol": "ETH"
-    },
-    {
-        "chain_id": 1666600000,
-        "name": "Harmony",
-        "symbol": "ONE"
     },
     {
         "chain_id": 1666600000,

--- a/keepkeylib/eth/ethereum_networks.json
+++ b/keepkeylib/eth/ethereum_networks.json
@@ -365,11 +365,6 @@
         "symbol": "ETH"
     },
     {
-        "chain_id": 42170,
-        "name": "Arbitrum Nova",
-        "symbol": "ETH"
-    },
-    {
         "chain_id": 42220,
         "name": "Celo",
         "symbol": "CELO"

--- a/keepkeylib/eth/ethereum_networks.json
+++ b/keepkeylib/eth/ethereum_networks.json
@@ -356,7 +356,7 @@
     },
     {
         "chain_id": 42161,
-        "name": "Arbitrum Mainnet",
+        "name": "Arbitrum One",
         "symbol": "ETH"
     },
     {

--- a/keepkeylib/eth/ethereum_networks.json
+++ b/keepkeylib/eth/ethereum_networks.json
@@ -1,67 +1,447 @@
 [
     {
         "chain_id": 1,
-        "symbol": "ETH",
-        "name": "Ethereum"
+        "name": "Ethereum Mainnet",
+        "symbol": "ETH"
     },
     {
         "chain_id": 2,
-        "symbol": "EXP",
-        "name": "Expanse"
+        "name": "Expanse",
+        "symbol": "EXP"
     },
     {
         "chain_id": 3,
-        "symbol": "tETH",
-        "name": "Ethereum Testnet Ropsten"
+        "name": "Ethereum Ropsten Testnet",
+        "symbol": "ETH"
     },
     {
         "chain_id": 4,
-        "symbol": "tETH",
-        "name": "Ethereum Testnet Rinkeby"
+        "name": "Ethereum Rinkeby Testnet",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 5,
+        "name": "Ethereum Goerli Testnet",
+        "symbol": "ETH"
     },
     {
         "chain_id": 8,
-        "symbol": "UBQ",
-        "name": "UBIQ"
+        "name": "UBIQ",
+        "symbol": "UBQ"
+    },
+    {
+        "chain_id": 10,
+        "name": "Optimism",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 19,
+        "name": "Songbird",
+        "symbol": "SGB"
     },
     {
         "chain_id": 20,
-        "symbol": "EOSC",
-        "name": "EOS Classic"
+        "name": "Elastos Smart Chain",
+        "symbol": "ELA"
+    },
+    {
+        "chain_id": 24,
+        "name": "Kardia",
+        "symbol": "KAI"
+    },
+    {
+        "chain_id": 25,
+        "name": "Cronos",
+        "symbol": "CRO"
     },
     {
         "chain_id": 28,
-        "symbol": "ETSC",
-        "name": "Ethereum Social"
+        "name": "Ethereum Social",
+        "symbol": "ETSC"
     },
     {
         "chain_id": 30,
-        "symbol": "RSK",
-        "name": "RSK"
+        "name": "Rootstock",
+        "symbol": "RBTC"
     },
     {
-        "chain_id": 31,
-        "symbol": "tRSK",
-        "name": "RSK Testnet"
+        "chain_id": 30,
+        "name": "Rootstock Testnet",
+        "symbol": "tRBTC"
+    },
+    {
+        "chain_id": 40,
+        "name": "Telos",
+        "symbol": "TLOS"
     },
     {
         "chain_id": 42,
-        "symbol": "tETH",
-        "name": "Ethereum Testnet Kovan"
+        "name": "Ethereum Kovan Testnet",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 44,
+        "name": "Darwinia Crab Network",
+        "symbol": "CRAB"
+    },
+    {
+        "chain_id": 56,
+        "name": "BNB Chain",
+        "symbol": "BNB"
+    },
+    {
+        "chain_id": 56,
+        "name": "BSC Smart Chain",
+        "symbol": "BNB"
+    },
+    {
+        "chain_id": 57,
+        "name": "Syscoin",
+        "symbol": "SYS"
     },
     {
         "chain_id": 61,
-        "symbol": "ETC",
-        "name": "Ethereum Classic"
+        "name": "Ethereum Classic Mainnet",
+        "symbol": "ETC"
     },
     {
         "chain_id": 62,
-        "symbol": "tETC",
-        "name": "Ethereum Classic Testnet"
+        "name": "Ethereum Classic Testnet",
+        "symbol": "ETC"
     },
     {
         "chain_id": 64,
-        "symbol": "ELLA",
-        "name": "Ellaism"
+        "name": "Ellaism",
+        "symbol": "ELLA"
+    },
+    {
+        "chain_id": 66,
+        "name": "OKXChain",
+        "symbol": "OKT"
+    },
+    {
+        "chain_id": 69,
+        "name": "Optimism Kovan Testnet",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 82,
+        "name": "Meter",
+        "symbol": "MTR"
+    },
+    {
+        "chain_id": 97,
+        "name": "BSC Smart Chain Testnet",
+        "symbol": "tBNB"
+    },
+    {
+        "chain_id": 100,
+        "name": "Gnosis",
+        "symbol": "xDAI"
+    },
+    {
+        "chain_id": 106,
+        "name": "Velas",
+        "symbol": "VLX"
+    },
+    {
+        "chain_id": 108,
+        "name": "ThunderCore",
+        "symbol": "TT"
+    },
+    {
+        "chain_id": 112,
+        "name": "Step",
+        "symbol": "FITFI"
+    },
+    {
+        "chain_id": 122,
+        "name": "58",
+        "symbol": "ONG"
+    },
+    {
+        "chain_id": 122,
+        "name": "Fuse",
+        "symbol": "FUSE"
+    },
+    {
+        "chain_id": 128,
+        "name": "Huobi ECO Chain",
+        "symbol": "HT"
+    },
+    {
+        "chain_id": 137,
+        "name": "Polygon Mainnet",
+        "symbol": "MATIC"
+    },
+    {
+        "chain_id": 199,
+        "name": "Bittorrent",
+        "symbol": "BTT"
+    },
+    {
+        "chain_id": 200,
+        "name": "Arbitrum on xDai",
+        "symbol": "xDai"
+    },
+    {
+        "chain_id": 250,
+        "name": "Fantom",
+        "symbol": "FTM"
+    },
+    {
+        "chain_id": 288,
+        "name": "Boba",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 295,
+        "name": "Hedera",
+        "symbol": "HBAR"
+    },
+    {
+        "chain_id": 300,
+        "name": "Optimism on Gnosis",
+        "symbol": "xDAI"
+    },
+    {
+        "chain_id": 314,
+        "name": "Filecoin",
+        "symbol": "FIL"
+    },
+    {
+        "chain_id": 321,
+        "name": "KCC",
+        "symbol": "KCS"
+    },
+    {
+        "chain_id": 324,
+        "name": "zkSync Era",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 361,
+        "name": "Theta",
+        "symbol": "TFUEL"
+    },
+    {
+        "chain_id": 416,
+        "name": "SX Network",
+        "symbol": "SX"
+    },
+    {
+        "chain_id": 420,
+        "name": "Optimism Goerli Testnet",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 592,
+        "name": "Astar",
+        "symbol": "ASTR"
+    },
+    {
+        "chain_id": 888,
+        "name": "Wanchain",
+        "symbol": "WAN"
+    },
+    {
+        "chain_id": 1088,
+        "name": "Metis",
+        "symbol": "METIS"
+    },
+    {
+        "chain_id": 1101,
+        "name": "Polygon zkEVM",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 1116,
+        "name": "CORE",
+        "symbol": "CORE"
+    },
+    {
+        "chain_id": 1231,
+        "name": "Ultron",
+        "symbol": "ULX"
+    },
+    {
+        "chain_id": 1284,
+        "name": "Moonbeam",
+        "symbol": "GLMR"
+    },
+    {
+        "chain_id": 1285,
+        "name": "Moonriver",
+        "symbol": "MOVR"
+    },
+    {
+        "chain_id": 1402,
+        "name": "Polygon zkEVM Testnet",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 2000,
+        "name": "Dogechain",
+        "symbol": "DOGE"
+    },
+    {
+        "chain_id": 2001,
+        "name": "Milkomeda C1",
+        "symbol": "mADA"
+    },
+    {
+        "chain_id": 2020,
+        "name": "Ronin",
+        "symbol": "RON"
+    },
+    {
+        "chain_id": 4099,
+        "name": "Bitindi",
+        "symbol": "$BNI"
+    },
+    {
+        "chain_id": 4689,
+        "name": "IoTeX",
+        "symbol": "IOTX"
+    },
+    {
+        "chain_id": 5177,
+        "name": "Tlchain",
+        "symbol": "TLC"
+    },
+    {
+        "chain_id": 5551,
+        "name": "Nahmii",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 7700,
+        "name": "Canto",
+        "symbol": "CANTO"
+    },
+    {
+        "chain_id": 8217,
+        "name": "Klaytn",
+        "symbol": "KLAY"
+    },
+    {
+        "chain_id": 9001,
+        "name": "Evmos",
+        "symbol": "EVMOS"
+    },
+    {
+        "chain_id": 10000,
+        "name": "Smart Bitcoin Cash",
+        "symbol": "BCH"
+    },
+    {
+        "chain_id": 22776,
+        "name": "Map",
+        "symbol": "MAP"
+    },
+    {
+        "chain_id": 28528,
+        "name": "Optimism Bedrock",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 32520,
+        "name": "Bitgert",
+        "symbol": "Brise"
+    },
+    {
+        "chain_id": 39797,
+        "name": "Energi",
+        "symbol": "NRG"
+    },
+    {
+        "chain_id": 42161,
+        "name": "Arbitrum Mainnet",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 42170,
+        "name": "Arbitrum Nova",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 42170,
+        "name": "Arbitrum Nova",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 42220,
+        "name": "Celo",
+        "symbol": "CELO"
+    },
+    {
+        "chain_id": 42262,
+        "name": "Oasis",
+        "symbol": "ROSE"
+    },
+    {
+        "chain_id": 43113,
+        "name": "Avalanche Fuji Testnet",
+        "symbol": "AVAX"
+    },
+    {
+        "chain_id": 43114,
+        "name": "Avalanche C-Chain",
+        "symbol": "AVAX"
+    },
+    {
+        "chain_id": 53935,
+        "name": "DFK",
+        "symbol": "JEWEL"
+    },
+    {
+        "chain_id": 71402,
+        "name": "Godwoken",
+        "symbol": "pCKB"
+    },
+    {
+        "chain_id": 80001,
+        "name": "Polygon Mumbai Testnet",
+        "symbol": "MATIC"
+    },
+    {
+        "chain_id": 90001,
+        "name": "FunctionX",
+        "symbol": "FX"
+    },
+    {
+        "chain_id": 421611,
+        "name": "Arbitrum Rinkeby",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 421613,
+        "name": "Arbitrum Goerli",
+        "symbol": "AGOR"
+    },
+    {
+        "chain_id": 888888,
+        "name": "Vision",
+        "symbol": "VS"
+    },
+    {
+        "chain_id": 1313161554,
+        "name": "Aurora",
+        "symbol": "ETH"
+    },
+    {
+        "chain_id": 1666600000,
+        "name": "Harmony",
+        "symbol": "ONE"
+    },
+    {
+        "chain_id": 1666600000,
+        "name": "Harmony",
+        "symbol": "ONE"
+    },
+    {
+        "chain_id": 383414847825,
+        "name": "Zeniq",
+        "symbol": "ZENIQ"
     }
 ]

--- a/keepkeylib/eth/uniswap_tokens.json
+++ b/keepkeylib/eth/uniswap_tokens.json
@@ -769,7 +769,7 @@
   },
   {
     "symbol": "GNO",
-    "identifier": "gnosis-gno",
+    "identifier": "gnosis",
     "displayName": "Gnosis",
     "contractAddress": "0x6810e776880c02933d47db1b9fc05908e5386b96",
     "precision": 18,
@@ -4540,6 +4540,341 @@
     "identifier": "xdai",
     "displayName": "xDAI Stake",
     "contractAddress": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "EXP",
+    "identifier": "expanse",
+    "displayName": "Expanse",
+    "contractAddress": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "TLOS",
+    "identifier": "Telos",
+    "displayName": "Telos",
+    "contractAddress": "0x7825e833d495f3d1c28872415a4aee339d26ac88",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "BNB",
+    "identifier": "BSC Smart Chain",
+    "displayName": "BSC Smart Chain",
+    "contractAddress": "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "FUSE",
+    "identifier": "Fuse",
+    "displayName": "Fuse",
+    "contractAddress": "0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "KCS",
+    "identifier": "KCC",
+    "displayName": "KCC",
+    "contractAddress": "0xf34960d9d60be18cc1d5afc1a6f012a723a28811",
+    "precision": 6
+  },
+  {
+    "symbol": "METIS",
+    "identifier": "Metis",
+    "displayName": "Metis",
+    "contractAddress": "0x9e32b13ce7f2e80a01932b42553652e053d6ed8e",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "IOTX",
+    "identifier": "IoTeX",
+    "displayName": "IoTeX",
+    "contractAddress": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "MAP",
+    "identifier": "Map",
+    "displayName": "Map",
+    "contractAddress": "0x9e976f211daea0d652912ab99b0dc21a7fd728e4",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "FX",
+    "identifier": "FunctionX",
+    "displayName": "FunctionX",
+    "contractAddress": "0x8c15ef5b4b21951d50e53e4fbda8298ffad25057",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "AVAX",
+    "identifier": "Avalanche",
+    "displayName": "Avalanche",
+    "contractAddress": "0x1ce0c2827e2ef14d5c4f29a091d735a204794041",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "WAVAX",
+    "identifier": "Avalanche",
+    "displayName": "Avalanche",
+    "contractAddress": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "OP",
+    "identifier": "optimism",
+    "displayName": "Optimism",
+    "contractAddress": "0x4200000000000000000000000000000000000042",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "ZENIQ",
+    "identifier": "zeniq",
+    "displayName": "Zeniq",
+    "contractAddress": "0x5b52bfb8062ce664d74bbcd4cd6dc7df53fd7233",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "AURORA",
+    "identifier": "aurora",
+    "displayName": "Aurora",
+    "contractAddress": "0xaaaaaa20d9e0e2461697782ef11675f668207961",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "ARB",
+    "identifier": "arbitrum",
+    "displayName": "Arbitrum",
+    "contractAddress": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "JEWEL",
+    "identifier": "defi-kingdoms",
+    "displayName": "DeFi Kingdoms",
+    "contractAddress": "0x72cb10c6bfa5624dd07ef608027e366bd690048f",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "CELO",
+    "identifier": "celo",
+    "displayName": "Celo",
+    "contractAddress": "0x471ece3750da237f93b8e339c536989b8978a438",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "Brise",
+    "identifier": "bitrise-token",
+    "displayName": "Bitgert",
+    "contractAddress": "0x8fff93e810a2edaafc326edee51071da9d398e83",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "MAP",
+    "identifier": "marcopolo",
+    "displayName": "MAP Protocol",
+    "contractAddress": "0x9e976f211daea0d652912ab99b0dc21a7fd728e4",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "CANTO",
+    "identifier": "canto",
+    "displayName": "CANTO",
+    "contractAddress": "0x826551890dc65655a0aceca109ab11abdbd7a07b",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "NII",
+    "identifier": "nahmii",
+    "displayName": "Nahmii",
+    "contractAddress": "0x7c8155909cd385f120a56ef90728dd50f9ccbe52",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "TLC",
+    "identifier": "tlchain",
+    "displayName": "TLChain",
+    "contractAddress": "0xcd6a8c968f6820f7163e7fb41f75048b92e4318d",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "IOTX",
+    "identifier": "iotex",
+    "displayName": "TLChain",
+    "contractAddress": "0x6fb3e0a217407efff7ca062d46c26e5d60a14d69",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "BNI",
+    "identifier": "bitindi-chain",
+    "displayName": "Bitindi Chain",
+    "contractAddress": "0x77fc65deda64f0cca9e3aea7b9d8521f4151882e",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "RON",
+    "identifier": "ronin",
+    "displayName": "Ronin",
+    "contractAddress": "0xe514d9deb7966c8be0ca922de8a064264ea6bcd4",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "DC",
+    "identifier": "dogechain",
+    "displayName": "Dogechain",
+    "contractAddress": "0x7b4328c127b85369d9f82ca0503b000d09cf9180",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "MOVR",
+    "identifier": "moonriver",
+    "displayName": "Moonriver",
+    "contractAddress": "0x98878b06940ae243284ca214f92bb71a2b032b8a",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "ULX",
+    "identifier": "ultron",
+    "displayName": "ULTRON",
+    "contractAddress": "0x5aa158404fed6b4730c13f49d3a7f820e14a636f",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "SX",
+    "identifier": "sx-network",
+    "displayName": "SX Network",
+    "contractAddress": "0x99fe3b1391503a1bc1788051347a1324bff41452",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "BOBA",
+    "identifier": "boba-network",
+    "displayName": "Boba Network",
+    "contractAddress": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "HT",
+    "identifier": "huobi-token",
+    "displayName": "Huobi",
+    "contractAddress": "0x6f259637dcd74c767781e37bc6133cd6a68aa161",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "FUSE",
+    "identifier": "fuse-network-token",
+    "displayName": "Fuse",
+    "contractAddress": "0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "FUSE",
+    "identifier": "fuse-network-token",
+    "displayName": "Fuse",
+    "contractAddress": "0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "FITFI",
+    "identifier": "step-app-fitfi",
+    "displayName": "Step App",
+    "contractAddress": "0x714f020c54cc9d104b6f4f6998c63ce2a31d1888",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "TT",
+    "identifier": "thunder-token",
+    "displayName": "ThunderCore",
+    "contractAddress": "0x1e053d89e08c24aa2ce5c5b4206744dc2d7bd8f5",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "VLX",
+    "identifier": "velas",
+    "displayName": "Velas",
+    "contractAddress": "0x8c543aed163909142695f2d2acd0d55791a9edb9",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "MTRG",
+    "identifier": "meter-governance",
+    "displayName": "Meter Governance",
+    "contractAddress": "0x228ebbee999c6a7ad74a6130e81b12f9fe237ba3",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "RBTC",
+    "identifier": "rootstock",
+    "displayName": "Rootstock RSK",
+    "contractAddress": "0x542fda317318ebf1d3deaf76e0b632741a7e677d",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "CRO",
+    "identifier": "crypto-com-chain",
+    "displayName": "Cronos",
+    "contractAddress": "0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "KAI",
+    "identifier": "kardiachain",
+    "displayName": "KardiaChain",
+    "contractAddress": "0xaf984e23eaa3e7967f3c5e007fbe397d8566d23d",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "ELA",
+    "identifier": "elastos",
+    "displayName": "Elastos",
+    "contractAddress": "0xe6fd75ff38adca4b97fbcd938c86b98772431867",
+    "precision": 18,
+    "network": "ETH"
+  },
+  {
+    "symbol": "UBQ",
+    "identifier": "ubiq",
+    "displayName": "Ubiq",
+    "contractAddress": "0xb1c5c9b97b35592777091cd34ffff141ae866abd",
     "precision": 18,
     "network": "ETH"
   }


### PR DESCRIPTION
* adds support for the top EVM networks sorted by market cap, bringing the total number of supported EVM networks to 106.