### PR TITLE
chore: pin portable canonical device protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, 'feature/**', 'fix/**', 'hotfix/**']
+    branches: [master, develop, reconcile/upstream-sync, 'feature/**', 'fix/**', 'hotfix/**']
   pull_request:
-    branches: [master, develop]
+    branches: [master, develop, reconcile/upstream-sync]
 
 jobs:
   # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- advance the python-keepkey device-protocol submodule from the pre-codegen staging commit to the final canonical staging merge
- keep Ironwood and x402 wire definitions unchanged while aligning the repository to the portable build commit

## Exact protocol pin

`b13391c772e3d46011f9ada8606c770b196e93d8`

## Validation

- 16 deterministic Zcash, seed fingerprint, and message-signing protocol binding tests passed
- canonical device-protocol PRs #115 and #116 passed Protocol CI before merge

No package publish is involved.
