### PR TITLE
fix(ci): request reviews safely for fork PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,11 +1,15 @@
 name: Request Copilot Review
 
 on:
-  pull_request:
+  # This workflow never checks out or executes pull-request code. Using the
+  # base-repository context is therefore safe and is required for cross-fork
+  # PRs, whose pull_request GITHUB_TOKEN is always downgraded to read-only.
+  pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   request-copilot-review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Cross-fork pull_request workflows receive a read-only GITHUB_TOKEN even when pull-requests: write is declared, so every automated Copilot request fails with HTTP 403. Switch this no-checkout/no-PR-code workflow to pull_request_target and skip draft PRs until ready_for_review.\n\nSecurity boundary: this workflow does not checkout or execute pull-request content; it only POSTs the event PR number to GitHub's requested_reviewers API.\n\nValidation: actionlint passed.