### PR TITLE
test(taproot): require physical signing confirmations

### DIFF
--- a/tests/test_msg_signtx_taproot.py
+++ b/tests/test_msg_signtx_taproot.py
@@ -87,7 +87,36 @@ class TestMsgSigntxTaproot(KeepKeyTest):
             script_type=proto_types.PAYTOADDRESS,
         )
 
-        (signatures, _) = self.client.sign_tx("Bitcoin", [inp1], [out1])
+        with self.client:
+            self.client.set_expected_responses([
+                proto.TxRequest(
+                    request_type=proto_types.TXINPUT,
+                    details=proto_types.TxRequestDetailsType(
+                        request_index=0)),
+                proto.TxRequest(
+                    request_type=proto_types.TXOUTPUT,
+                    details=proto_types.TxRequestDetailsType(
+                        request_index=0)),
+                proto.ButtonRequest(
+                    code=proto_types.ButtonRequest_ConfirmOutput),
+                proto.ButtonRequest(
+                    code=proto_types.ButtonRequest_SignTx),
+                proto.TxRequest(
+                    request_type=proto_types.TXINPUT,
+                    details=proto_types.TxRequestDetailsType(
+                        request_index=0)),
+                proto.TxRequest(
+                    request_type=proto_types.TXOUTPUT,
+                    details=proto_types.TxRequestDetailsType(
+                        request_index=0)),
+                proto.TxRequest(
+                    request_type=proto_types.TXINPUT,
+                    details=proto_types.TxRequestDetailsType(
+                        request_index=0)),
+                proto.TxRequest(request_type=proto_types.TXFINISHED),
+            ])
+            (signatures, _) = self.client.sign_tx(
+                "Bitcoin", [inp1], [out1])
 
         self.assertEqual(len(signatures), 1)
         self.assertEqual(hexlify(signatures[0]).decode(), EXPECTED_WITNESS)


### PR DESCRIPTION
## Problem

Physical testing of the exact v7.15.0-rc23 full firmware artifact returned a valid 64-byte P2TR Schnorr signature without showing either transaction confirmation on the KeepKey. A P2WPKH control transaction on the same device and transport did require physical approval.

The deterministic P2TR vector checked only the signature bytes, so it could pass without asserting the security-critical button policy.

## Change

Pin the complete expected response sequence for the real P2TR-input vector. The device must emit `ButtonRequest_ConfirmOutput` and then `ButtonRequest_SignTx` before phase-2 input/output requests and Schnorr signing.

This is a test-only change; it does not alter the wire schema or device protocol.

## Verification

- `python3 -m py_compile tests/test_msg_signtx_taproot.py`
- `git diff --check`
- Full emulator/integration execution is performed by the firmware PR after pinning this exact SHA.

## Hardware evidence

- Candidate: v7.15.0-rc23, full artifact SHA-256 `92b292eb460c462df9084131a67a78f24fd4061b6d11822401dddd47c07c967f`
- P2TR: valid serialization and 64-byte signature, no physical transaction confirmation
- P2WPKH control: recipient and fee were displayed and physically approved

This PR is intentionally draft until the paired firmware fail-closed guard and exact-head integration run are green.