### PR TITLE
test(reset): display_random is accepted and ignored

### DIFF
--- a/tests/test_msg_resetdevice.py
+++ b/tests/test_msg_resetdevice.py
@@ -245,10 +245,11 @@ class TestDeviceReset(common.KeepKeyTest):
                                                language='english',
                                                label='test'))
 
-        self.assertIsInstance(ret, proto.ButtonRequest)
-        self.client.debug.press_yes()
-        ret = self.client.call_raw(proto.ButtonAck())
-
+        # display_random=True above is deliberate: the field stays in the wire
+        # schema for host compatibility but production firmware ignores it,
+        # because internal entropy is seed pre-image material. A host that
+        # sets it must get a NORMAL reset -- no Internal Entropy screen -- so
+        # the very next message is the PIN request, not a ButtonRequest.
         self.assertIsInstance(ret, proto.PinMatrixRequest)
 
         # Enter PIN for first time
@@ -318,10 +319,11 @@ class TestDeviceReset(common.KeepKeyTest):
                                                language='english',
                                                label='test'))
 
-        self.assertIsInstance(ret, proto.ButtonRequest)
-        self.client.debug.press_yes()
-        ret = self.client.call_raw(proto.ButtonAck())
-
+        # display_random=True above is deliberate: the field stays in the wire
+        # schema for host compatibility but production firmware ignores it,
+        # because internal entropy is seed pre-image material. A host that
+        # sets it must get a NORMAL reset -- no Internal Entropy screen -- so
+        # the very next message is the PIN request, not a ButtonRequest.
         self.assertIsInstance(ret, proto.PinMatrixRequest)
 
         # Enter PIN for first time


### PR DESCRIPTION
Pairs with firmware BitHighlander/keepkey-firmware#336, which stops rendering the Internal Entropy screen.

## Why the firmware changed

Internal entropy is seed pre-image material. A host that supplies `ext_entropy` and reads that screen once computes `SHA256(shown || ext_entropy)` and derives the seed. Note this is unaffected by dice entropy — the displayed value is already post-mix, so dice change nothing about the leak.

## Why these tests failed

`test_reset_device_pin` and `test_failed_pin` sent `display_random=True` and asserted the resulting `ButtonRequest` before the PIN matrix. That screen no longer exists, so both failed — this was the only red job on #336.

## The fix

Rather than dropping `display_random` from the requests, they still send it `=True` and now assert the next message is `PinMatrixRequest`. That turns a broken assertion into a direct test of the compatibility claim: the field stays decodable on the wire and changes nothing observable.

## Verification

6/6 in `test_msg_resetdevice.py` against an emulator built from the paired firmware branch — including `test_reset_device_dice`, confirming dice entropy and the entropy-screen removal coexist. Firmware side was 14/14 green with `python-integration-tests` included, and #336 has since merged to alpha.