### PR TITLE
test(7.15): reconcile the branch with what rc29 actually pins, plus the chain_id regression

### DIFF
--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -344,7 +344,7 @@ def detect_fw():
 # state how much of the run it covers.  Without this the PDF silently implies
 # that its catalog IS the test suite -- an RC audit read "no dice in the report"
 # as "dice is untested" when test_reset_device_dice had in fact run green.
-JUNIT_CENSUS = {'ran': 0, 'native': 0}
+JUNIT_CENSUS = {'ran': 0, 'skipped': 0, 'native': 0}
 
 
 def parse_junit(path):
@@ -367,6 +367,11 @@ def parse_junit(path):
         elif tc.find('skipped') is not None: status = 'skip'
         else: status = 'pass'
         JUNIT_CENSUS['ran'] += 1
+        # 'ran' counts every collected testcase, skips included. A version-gated
+        # feature test that SKIPs on an older emulator is NOT evidence the feature
+        # works, so the two must never be reported as one number.
+        if status == 'skip':
+            JUNIT_CENSUS['skipped'] += 1
         # Extract module from classname: tests.test_msg_foo.TestBar → test_msg_foo
         mod = ''
         if cls:
@@ -2053,10 +2058,10 @@ SECTIONS = [
           'it drives a ScriptedTransport with canned responses and never reaches a device. It '
           'proves the client builds and orders the messages correctly; it proves nothing about '
           'firmware behaviour, and it can never produce an OLED frame. ZcashSignPCZT is not sent '
-          'to a device anywhere in this suite, so the on-device shielded signing path -- '
-          'including the per-output confirm that is the designed verification gate for Orchard '
-          'output values -- has no automated coverage at all. Shielded signing must be walked on '
-          'real hardware.',
+          'to a device anywhere in THIS module. On-device shielded signing is covered '
+          'separately by test_msg_zcash_sign_pczt_device (see Z22), which drives a real '
+          'device and asserts the per-output confirm screens; this module proves only that '
+          'the client builds and orders the messages correctly.',
           []),
          ('Z18', 'test_msg_zcash_sign_pczt',
           'test_missing_is_spend_is_rejected_before_device_call',
@@ -2200,10 +2205,13 @@ def render(output_path, fw_version, results, screenshot_dir=None):
     ran = JUNIT_CENSUS['ran']
     if ran:
         pb.gap(3)
-        for line in _w('Scope: this report is a curated catalog of %d tests. The CI run executed %d '
-                       '(%d of them native firmware unit tests). Absence from this report is NOT '
+        skipped = JUNIT_CENSUS['skipped']
+        for line in _w('Scope: this report is a curated catalog of %d tests. The CI run collected %d '
+                       '(%d of them native firmware unit tests); %d SKIPPED and did not execute, '
+                       'usually because the emulator predates the firmware the test targets -- a skip '
+                       'is not evidence the feature works. Absence from this report is NOT '
                        'evidence that a feature is untested -- check the JUnit artifacts.'
-                       % (total, ran, JUNIT_CENSUS['native']), 100):
+                       % (total, ran, JUNIT_CENSUS['native'], skipped), 100):
             pb.text(8, line, color=GRAY)
     pb.gap(6)
     pb.text(12, 'Sections', bold=True)

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -745,11 +745,22 @@ SECTIONS = [
           'Bytes past the declared roll count must not affect the result, so uninitialized tail '
           'bytes of the roll buffer can never leak into seed material.',
           []),
-         ('K8', 'Storage', 'PinKdfV16RewrapsToV19AfterCorrectPin',
-          'v16 storage unlocks and rewraps to v19',
-          'The migration path for the hardened PIN KDF: an existing device on the old format must '
-          'still unlock with its current PIN and then be rewrapped. If this regressed, every '
+         ('K8', 'Storage', 'PinKdfRewrapsToActiveVersionAfterCorrectPin',
+          'Correct PIN unlocks and rewraps to the ACTIVE KDF',
+          'The migration path for the hardened PIN KDF: an existing device must still unlock with '
+          'its current PIN, and any rewrap must target whatever KDF the build actually has '
+          'enabled. Renamed from PinKdfV16RewrapsToV19AfterCorrectPin because it is no longer '
+          'v19-specific -- the test now asserts BOTH sides of the STORAGE_PIN_KDF_V19 gate, so it '
+          'is meaningful in the shipping build where v19 is off. If this regressed, every '
           'upgrading device would be locked out of its own seed.',
+          []),
+         ('K8b', 'Storage', 'PinUnlocksAfterRebootUnderV17',
+          'The PIN still opens the wallet after a reboot',
+          'The whole round trip in device order: create, set a PIN, serialize the V17 record as '
+          'storage_commit() does, reload into fresh state as a boot would, unlock, decrypt. Every '
+          'other storage test stays in RAM, and the wallet lockout this guards against lived '
+          'exactly on the serialize/reboot boundary -- a wrap the persisted record could not '
+          'describe, so the next boot derived the wrong KDF and every PIN failed.',
           []),
          ('K9', 'Storage', 'PinKdfV2FlagIsVersionedInV19',
           'KDF version flag is recorded in v19',

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -2038,7 +2038,14 @@ SECTIONS = [
           'test_private_send_preserves_compact_real_spend_order',
           'Private send preserves real-spend signature order',
           'Compact device signatures remain ordered by the real-spend actions when dummy actions '
-          'are interleaved.',
+          'are interleaved. OFFLINE CONTRACT TEST -- like every test in test_msg_zcash_sign_pczt, '
+          'it drives a ScriptedTransport with canned responses and never reaches a device. It '
+          'proves the client builds and orders the messages correctly; it proves nothing about '
+          'firmware behaviour, and it can never produce an OLED frame. ZcashSignPCZT is not sent '
+          'to a device anywhere in this suite, so the on-device shielded signing path -- '
+          'including the per-output confirm that is the designed verification gate for Orchard '
+          'output values -- has no automated coverage at all. Shielded signing must be walked on '
+          'real hardware.',
           []),
          ('Z18', 'test_msg_zcash_sign_pczt',
           'test_missing_is_spend_is_rejected_before_device_call',

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -340,9 +340,22 @@ def detect_fw():
         v = f'{r.major_version}.{r.minor_version}.{r.patch_version}'; c.close(); return v
     except: return None
 
+# Census of everything the merged JUnit actually contained, so the report can
+# state how much of the run it covers.  Without this the PDF silently implies
+# that its catalog IS the test suite -- an RC audit read "no dice in the report"
+# as "dice is untested" when test_reset_device_dice had in fact run green.
+JUNIT_CENSUS = {'ran': 0, 'native': 0}
+
+
 def parse_junit(path):
     """Parse junit XML for pass/fail. Returns dict keyed by 'module::method' (precise)
-    and 'method' (fallback). Module is extracted from classname: tests.test_msg_foo.TestBar → test_msg_foo."""
+    and 'method' (fallback). Module is extracted from classname: tests.test_msg_foo.TestBar → test_msg_foo.
+
+    Native gtest suites carry a bare classname ("Dice", "Storage") with no dotted
+    python module, so they get keyed as 'Suite::Test'. They used to produce no
+    'mod::meth' key at all, which made every native unit test structurally
+    impossible to put in SECTIONS -- the firmware-unit XMLs were merged in and
+    then silently unusable."""
     if not path or not os.path.exists(path): return {}
     import xml.etree.ElementTree as ET
     results = {}
@@ -353,6 +366,7 @@ def parse_junit(path):
         elif tc.find('error') is not None: status = 'error'
         elif tc.find('skipped') is not None: status = 'skip'
         else: status = 'pass'
+        JUNIT_CENSUS['ran'] += 1
         # Extract module from classname: tests.test_msg_foo.TestBar → test_msg_foo
         mod = ''
         if cls:
@@ -361,6 +375,9 @@ def parse_junit(path):
                 if p.startswith('test_msg_') or p.startswith('test_sign_') or p.startswith('test_verify_'):
                     mod = p
                     break
+            if not mod and '.' not in cls:
+                mod = cls               # native gtest suite
+                JUNIT_CENSUS['native'] += 1
             results[f'{cls}.{name}'] = status
         # Key by module::method (disambiguates collisions like test_sign_btc_eth_swap)
         if mod:
@@ -670,6 +687,84 @@ SECTIONS = [
           'Enter a non-BIP-39 word ("zz") during cipher recovery with enforce_wordlist=True. '
           'Firmware must reject immediately with Failure instead of silently accepting.',
           ['Wordlist rejection warning']),
+     ]),
+
+    ('K', 'Seed Generation Hardening (7.15)', '7.15.0',
+     'The 7.15 changes to how a seed comes into existence: user-supplied dice entropy folded in '
+     'on-device, and the PIN key-derivation rewrap. These ran green from the first 7.15 RC but '
+     'appeared nowhere in this report, because the catalog could not reference native firmware '
+     'unit tests at all and nobody had catalogued the two new pyk cases. Absent evidence read as '
+     'absent coverage during an RC audit, which is exactly the failure this section exists to '
+     'prevent.',
+     [
+         'DICE: user rolls a d6 on-device; short press advances 1-6, long press commits, undo backs out.',
+         'The roll string is hashed and the digest confirmed on the OLED before it is mixed in.',
+         'MIX: int_entropy = SHA256(int_entropy || rolls), folded in BEFORE the host EntropyRequest,',
+         'so the device commits to its own contribution first and the host cannot choose the seed.',
+         'ABORT: any aborted reset must disarm EntropyAck, or a later host EntropyAck would derive',
+         'a seed from sha256(0*32 || host_bytes) -- entirely host-chosen. That is K2.',
+         'PIN KDF: a v16 storage blob must still unlock and then rewrap to v19, or the upgrade bricks.',
+     ],
+     [
+         ('K1', 'test_msg_resetdevice', 'test_reset_device_dice',
+          'Dice entropy end-to-end',
+          'Drives the full on-device dice flow over DebugLink: 99 rolls injected in chunks with undo '
+          'exercised, extras past the cap dropped. Asserts the device-computed digest equals '
+          'SHA256 of exactly the expected roll string, then derives the mnemonic from the post-mix '
+          'internal entropy and compares -- which is what proves the rolls actually reached the seed '
+          'rather than being collected and discarded.',
+          ['Dice entry screen', 'Digest confirmation']),
+         ('K2', 'test_msg_resetdevice', 'test_reset_reentry_disarms_entropy_ack',
+          'Aborted reset disarms EntropyAck',
+          'Regression for a host-chosen-seed hole: reset_init aborts left awaiting_entropy set from '
+          'an earlier run while zeroing int_entropy, so a following EntropyAck derived the seed '
+          'from host bytes alone. Arms a reset, re-enters with dice, cancels, and asserts the '
+          'next EntropyAck is refused with "Not in Reset mode" and the device stays uninitialized.',
+          []),
+         ('K3', 'Dice', 'RollsForStrength',
+          'Roll count per seed strength',
+          'd6 carries log2(6)=2.585 bits, so 128/192/256-bit seeds need 50/75/99 rolls '
+          '(the Coldcard convention). A short count would silently weaken the seed.',
+          []),
+         ('K4', 'Dice', 'MixZeroEntropyVector',
+          'Mix known-answer vector (zero entropy)',
+          'SHA256(0x00*32 || "123456") against a hardcoded digest. Pins the mix construction so a '
+          'refactor cannot quietly change how dice enter the seed.',
+          []),
+         ('K5', 'Dice', 'MixNonZeroEntropyVector',
+          'Mix known-answer vector (non-zero entropy)',
+          'Same construction with a non-zero starting entropy buffer, pinned to a hardcoded digest.',
+          []),
+         ('K6', 'Dice', 'MixDependsOnRolls',
+          'Different rolls produce different entropy',
+          'Two mixes differing only in the final roll must diverge. Catches a mix that ignores its '
+          'roll argument -- the failure mode where dice appear to work and contribute nothing.',
+          []),
+         ('K7', 'Dice', 'MixUsesExactCount',
+          'Only the counted rolls contribute',
+          'Bytes past the declared roll count must not affect the result, so uninitialized tail '
+          'bytes of the roll buffer can never leak into seed material.',
+          []),
+         ('K8', 'Storage', 'PinKdfV16RewrapsToV19AfterCorrectPin',
+          'v16 storage unlocks and rewraps to v19',
+          'The migration path for the hardened PIN KDF: an existing device on the old format must '
+          'still unlock with its current PIN and then be rewrapped. If this regressed, every '
+          'upgrading device would be locked out of its own seed.',
+          []),
+         ('K9', 'Storage', 'PinKdfV2FlagIsVersionedInV19',
+          'KDF version flag is recorded in v19',
+          'The new KDF is marked in the storage version band, so firmware can tell which derivation '
+          'a blob was written with instead of guessing.',
+          []),
+         ('K10', 'Storage', 'StorageUpgrade_Normal',
+          'Normal storage upgrade path',
+          'Baseline upgrade across storage versions with policies and cache preserved.',
+          []),
+         ('K11', 'Storage', 'NoopSecMigrate',
+          'Idempotent security migration',
+          'Re-running the migration on already-migrated storage must be a no-op rather than a '
+          'second rewrap.',
+          []),
      ]),
 
     ('B', 'Bitcoin', '7.0.0',
@@ -2044,6 +2139,18 @@ def render(output_path, fw_version, results, screenshot_dir=None):
     if build_label:
         for line in _w(f'Candidate: {build_label}', 95):
             pb.text(8, line, bold=True)
+    # Scope of this document. The catalog is a curated subset, and saying so is
+    # the difference between evidence and a misleading completeness claim: an RC
+    # audit grepped this PDF for feature keywords, found none, and reported four
+    # features as untested when their tests had run green in the same CI run.
+    ran = JUNIT_CENSUS['ran']
+    if ran:
+        pb.gap(3)
+        for line in _w('Scope: this report is a curated catalog of %d tests. The CI run executed %d '
+                       '(%d of them native firmware unit tests). Absence from this report is NOT '
+                       'evidence that a feature is untested -- check the JUnit artifacts.'
+                       % (total, ran, JUNIT_CENSUS['native']), 100):
+            pb.text(8, line, color=GRAY)
     pb.gap(6)
     pb.text(12, 'Sections', bold=True)
     _hdr_withheld = _hdr_pending = False

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -2068,6 +2068,42 @@ SECTIONS = [
           'Duplicate action requests rejected',
           'A repeated device request for the same action index aborts the streaming session.',
           []),
+         ('Z22', 'test_msg_zcash_sign_pczt_device',
+          'test_shielded_output_review_is_two_screens',
+          'Shielded output review: amount and full address (ON DEVICE)',
+          'The first test in this suite that sends ZcashSignPCZT to an actual device -- Z15-Z21 '
+          'above are offline contract tests against a scripted transport. Signs a shielded-only '
+          'transaction built from the firmware\'s own known-answer note vector, so the device '
+          'accepts its recomputed commitment, and asserts the output review is two screens. It '
+          'has to be: a unified address is 106 characters, three full body rows, and the body is '
+          'three rows total, so a single confirm holding the question, the address and the amount '
+          'renders 76 characters of address and silently drops the rest along with the amount. '
+          'That screen is the verification gate for Orchard output values -- total_amount on the '
+          'summary is a host-supplied prompt -- so the amount vanishing there is the whole trust '
+          'story. Verified as a regression test: against the shipped 7.15.0 RC emulator it fails '
+          'with "expected 2 ConfirmOutput screens, got 1".',
+          ['Shielded amount review', 'Shielded recipient address']),
+         ('Z23', 'test_msg_zcash_sign_pczt_device',
+          'test_note_commitment_binds_the_recipient',
+          'Tampered recipient breaks the note commitment (ON DEVICE)',
+          'Flipping one bit of the recipient makes the device-recomputed cmx disagree with the '
+          'supplied commitment, and signing is refused. This is what stops a host displaying one '
+          'recipient while committing to another.',
+          []),
+         ('Z24', 'test_msg_zcash_sign_pczt_device',
+          'test_pool_selection_is_honoured',
+          'Orchard commitment rejected under the Ironwood pool (ON DEVICE)',
+          'The same note commits to a different value in each pool, so offering the Orchard '
+          'commitment while declaring Ironwood must be rejected. Passes trivially if the device '
+          'ignores shielded_pool, which is why it is paired with Z25.',
+          []),
+         ('Z25', 'test_msg_zcash_sign_pczt_device',
+          'test_ironwood_note_is_accepted',
+          'Ironwood commitment for the same note is accepted (ON DEVICE)',
+          'The positive half of Z24: identical inputs, Ironwood commitment, accepted. Together '
+          'they prove the pool branch is selected by shielded_pool rather than one path serving '
+          'both.',
+          []),
      ]),
 
     ('D', 'BIP-85 Child Derivation', '7.14.0',

--- a/tests/test_msg_ethereum_signtx.py
+++ b/tests/test_msg_ethereum_signtx.py
@@ -405,6 +405,65 @@ class TestMsgEthereumSigntx(common.KeepKeyTest):
             "67297089e0ba53c29dda1aafc23fce64a772c5433e127e5885edc03ece4670c9",
         )
 
+    def test_ethereum_eip_1559_multibyte_chain_id(self):
+        """EIP-1559 must hash the WHOLE chain_id, not just its low byte.
+
+        Regression for the multi-byte chain_id bug (firmware ed6db167). The
+        EIP-1559 hash step used hash_rlp_field((uint8_t*)&chain_id, 1), which on
+        little-endian ARM fed only the least-significant byte into keccak. For
+        Base (8453 = 0x2105) that hashed 0x05, so the signature recovered to an
+        unrelated address with no funds. The RLP *length* was computed correctly
+        from the full value and the legacy EIP-155 path was always correct —
+        only the EIP-1559 hash was wrong. Affected: Base (8453), Arbitrum
+        (42161), Avalanche (43114). Unaffected: ETH (1), OP (10), BSC (56),
+        Polygon (137) — all single-byte.
+
+        Every other EIP-1559 case in this file uses chain_id 1 or 3, so the bug
+        had no coverage in the file that tests the feature.
+
+        A golden r/s would need a device run to produce, so this is a
+        differential. Sign one identical transaction under two chain ids the
+        BUGGY firmware cannot tell apart:
+
+            8453 = 0x2105   low byte 0x05, two-byte value
+            4357 = 0x1105   low byte 0x05, two-byte value
+
+        Same low byte AND same RLP length header, so the broken code hashes a
+        byte-identical pre-image for both. Signing is deterministic (RFC 6979),
+        so buggy firmware returns the SAME signature twice and this fails.
+        Correct firmware hashes 0x21 0x05 vs 0x11 0x05, which must differ.
+
+        Note a comparison against chain_id=5 would NOT work: the RLP length was
+        always derived from the full value, so the buggy pre-image for 8453 is
+        malformed rather than equal to a well-formed single-byte encoding. The
+        twin must match on both low byte and byte-width.
+        """
+        self.requires_fullFeature()
+        self.requires_firmware("7.15.0")
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        def sign(chain_id):
+            return self.client.ethereum_sign_tx(
+                n=[0x80000000 | 44, 0x80000000 | 60, 0x80000000, 0, 0],
+                nonce=0,
+                gas_limit=0x5ac3,
+                max_fee_per_gas=0x16854be509,
+                max_priority_fee_per_gas=0x540ae480,
+                to=binascii.unhexlify("fc0cc6e85dff3d75e3985e0cb83b090cfd498dd1"),
+                value=0x1550f7dca70000,
+                chain_id=chain_id,
+            )
+
+        _, base_r, base_s = sign(8453)
+        _, twin_r, twin_s = sign(4357)
+
+        self.assertNotEqual(
+            (binascii.hexlify(base_r), binascii.hexlify(base_s)),
+            (binascii.hexlify(twin_r), binascii.hexlify(twin_s)),
+            "chain_id 8453 and 4357 produced the same signature — only the low "
+            "byte of chain_id reached the EIP-1559 hash",
+        )
+
     def test_ethereum_signtx_nodata_eip_1559(self):
         self.requires_fullFeature()
         self.requires_firmware("7.2.1")

--- a/tests/test_msg_resetdevice.py
+++ b/tests/test_msg_resetdevice.py
@@ -235,6 +235,14 @@ class TestDeviceReset(common.KeepKeyTest):
         self.assertFalse(ret.initialized)
 
     def test_reset_device_pin(self):
+        # Firmware 7.15.0 removed the Internal Entropy screen (fw 320f0eb5,
+        # "no entropy display"): internal entropy is seed pre-image material, so a
+        # host that sets display_random and reads that screen could compute
+        # SHA256(shown || ext) and derive the seed. This test asserts the POST-removal
+        # flow (next message is PinMatrixRequest, not a ButtonRequest), so it must
+        # SKIP on older firmware rather than fail against a screen that legitimately
+        # still exists there.
+        self.requires_firmware("7.15.0")
         external_entropy = b'zlutoucky kun upel divoke ody' * 2
         strength = 128
 
@@ -309,6 +317,14 @@ class TestDeviceReset(common.KeepKeyTest):
         self.client.call_raw(proto.Cancel())
 
     def test_failed_pin(self):
+        # Firmware 7.15.0 removed the Internal Entropy screen (fw 320f0eb5,
+        # "no entropy display"): internal entropy is seed pre-image material, so a
+        # host that sets display_random and reads that screen could compute
+        # SHA256(shown || ext) and derive the seed. This test asserts the POST-removal
+        # flow (next message is PinMatrixRequest, not a ButtonRequest), so it must
+        # SKIP on older firmware rather than fail against a screen that legitimately
+        # still exists there.
+        self.requires_firmware("7.15.0")
         external_entropy = 'zlutoucky kun upel divoke ody' * 2
         strength = 128
 

--- a/tests/test_msg_resetdevice.py
+++ b/tests/test_msg_resetdevice.py
@@ -245,10 +245,11 @@ class TestDeviceReset(common.KeepKeyTest):
                                                language='english',
                                                label='test'))
 
-        self.assertIsInstance(ret, proto.ButtonRequest)
-        self.client.debug.press_yes()
-        ret = self.client.call_raw(proto.ButtonAck())
-
+        # display_random=True above is deliberate: the field stays in the wire
+        # schema for host compatibility but production firmware ignores it,
+        # because internal entropy is seed pre-image material. A host that
+        # sets it must get a NORMAL reset -- no Internal Entropy screen -- so
+        # the very next message is the PIN request, not a ButtonRequest.
         self.assertIsInstance(ret, proto.PinMatrixRequest)
 
         # Enter PIN for first time
@@ -318,10 +319,11 @@ class TestDeviceReset(common.KeepKeyTest):
                                                language='english',
                                                label='test'))
 
-        self.assertIsInstance(ret, proto.ButtonRequest)
-        self.client.debug.press_yes()
-        ret = self.client.call_raw(proto.ButtonAck())
-
+        # display_random=True above is deliberate: the field stays in the wire
+        # schema for host compatibility but production firmware ignores it,
+        # because internal entropy is seed pre-image material. A host that
+        # sets it must get a NORMAL reset -- no Internal Entropy screen -- so
+        # the very next message is the PIN request, not a ButtonRequest.
         self.assertIsInstance(ret, proto.PinMatrixRequest)
 
         # Enter PIN for first time

--- a/tests/test_msg_resetdevice.py
+++ b/tests/test_msg_resetdevice.py
@@ -235,14 +235,6 @@ class TestDeviceReset(common.KeepKeyTest):
         self.assertFalse(ret.initialized)
 
     def test_reset_device_pin(self):
-        # Firmware 7.15.0 removed the Internal Entropy screen (fw 320f0eb5,
-        # "no entropy display"): internal entropy is seed pre-image material, so a
-        # host that sets display_random and reads that screen could compute
-        # SHA256(shown || ext) and derive the seed. This test asserts the POST-removal
-        # flow (next message is PinMatrixRequest, not a ButtonRequest), so it must
-        # SKIP on older firmware rather than fail against a screen that legitimately
-        # still exists there.
-        self.requires_firmware("7.15.0")
         external_entropy = b'zlutoucky kun upel divoke ody' * 2
         strength = 128
 
@@ -254,10 +246,20 @@ class TestDeviceReset(common.KeepKeyTest):
                                                label='test'))
 
         # display_random=True above is deliberate: the field stays in the wire
-        # schema for host compatibility but production firmware ignores it,
-        # because internal entropy is seed pre-image material. A host that
-        # sets it must get a NORMAL reset -- no Internal Entropy screen -- so
-        # the very next message is the PIN request, not a ButtonRequest.
+        # schema for host compatibility. Firmware 7.15.0 (fw 320f0eb5, "no
+        # entropy display") stopped honouring it -- internal entropy is seed
+        # pre-image material, and a host that sets the flag and reads that
+        # screen once can compute SHA256(shown || ext) and derive the seed.
+        #
+        # Branch on the version rather than skipping the test: everything below
+        # (PIN entry, EntropyRequest/Ack, mnemonic derivation) is version-
+        # independent and must keep running on older firmware.
+        f = self.client.features
+        if (f.major_version, f.minor_version, f.patch_version) < (7, 15, 0):
+            # Pre-7.15: the Internal Entropy screen legitimately still exists.
+            self.assertIsInstance(ret, proto.ButtonRequest)
+            self.client.debug.press_yes()
+            ret = self.client.call_raw(proto.ButtonAck())
         self.assertIsInstance(ret, proto.PinMatrixRequest)
 
         # Enter PIN for first time
@@ -317,14 +319,6 @@ class TestDeviceReset(common.KeepKeyTest):
         self.client.call_raw(proto.Cancel())
 
     def test_failed_pin(self):
-        # Firmware 7.15.0 removed the Internal Entropy screen (fw 320f0eb5,
-        # "no entropy display"): internal entropy is seed pre-image material, so a
-        # host that sets display_random and reads that screen could compute
-        # SHA256(shown || ext) and derive the seed. This test asserts the POST-removal
-        # flow (next message is PinMatrixRequest, not a ButtonRequest), so it must
-        # SKIP on older firmware rather than fail against a screen that legitimately
-        # still exists there.
-        self.requires_firmware("7.15.0")
         external_entropy = 'zlutoucky kun upel divoke ody' * 2
         strength = 128
 
@@ -336,10 +330,20 @@ class TestDeviceReset(common.KeepKeyTest):
                                                label='test'))
 
         # display_random=True above is deliberate: the field stays in the wire
-        # schema for host compatibility but production firmware ignores it,
-        # because internal entropy is seed pre-image material. A host that
-        # sets it must get a NORMAL reset -- no Internal Entropy screen -- so
-        # the very next message is the PIN request, not a ButtonRequest.
+        # schema for host compatibility. Firmware 7.15.0 (fw 320f0eb5, "no
+        # entropy display") stopped honouring it -- internal entropy is seed
+        # pre-image material, and a host that sets the flag and reads that
+        # screen once can compute SHA256(shown || ext) and derive the seed.
+        #
+        # Branch on the version rather than skipping the test: everything below
+        # (PIN entry, EntropyRequest/Ack, mnemonic derivation) is version-
+        # independent and must keep running on older firmware.
+        f = self.client.features
+        if (f.major_version, f.minor_version, f.patch_version) < (7, 15, 0):
+            # Pre-7.15: the Internal Entropy screen legitimately still exists.
+            self.assertIsInstance(ret, proto.ButtonRequest)
+            self.client.debug.press_yes()
+            ret = self.client.call_raw(proto.ButtonAck())
         self.assertIsInstance(ret, proto.PinMatrixRequest)
 
         # Enter PIN for first time

--- a/tests/test_msg_zcash_sign_pczt_device.py
+++ b/tests/test_msg_zcash_sign_pczt_device.py
@@ -1,0 +1,298 @@
+"""Device-level Zcash shielded signing.
+
+Every other PCZT test in this suite is an offline contract test: they drive a
+ScriptedTransport with canned responses and never reach a device. That left the
+on-device shielded path with no automated coverage at all -- and it is not a
+quiet corner of the firmware. fsm_msg_zcash.h calls total_amount "a summary
+prompt" and delegates verification of Orchard output *values* to the per-output
+confirm screen, so that screen is the whole trust story for a shielded send.
+
+Nothing had ever rendered it. The RC run captured 1037 OLED frames and not one
+came from a shielded flow, which is how a confirm that could not physically fit
+its amount line shipped unnoticed.
+
+The note fixtures are the known-answer vectors from
+unittests/firmware/zcash.cpp (OrchardNoteCommitment_KnownVectorAndProgress,
+IronwoodNoteCommitment_V3KnownVector, OrchardReceiverToUnifiedAddress_KnownVector),
+so the device's own cmx recomputation accepts them. Same note under both pools,
+with a different commitment each -- which is what lets us prove the device
+actually honours shielded_pool instead of ignoring it.
+"""
+
+import hashlib
+import struct
+import unittest
+
+import common
+
+from keepkeylib import messages_pb2 as proto
+from keepkeylib import types_pb2 as proto_types
+from keepkeylib import messages_zcash_pb2 as zcash_proto
+
+
+H = 0x80000000
+ADDRESS_N = [H + 32, H + 133, H]
+
+# --- known-answer note, from unittests/firmware/zcash.cpp -------------------
+RECIPIENT = bytes.fromhex(
+    '3c150e6098b861716cc7f62835f69feb302193c92660444f26624fd13e00ea7a'
+    'c774cd55074d6367efef37')                                    # 43 bytes
+RHO = bytes.fromhex(
+    '112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00')
+RSEED = bytes.fromhex(
+    'cafebabedeadbeef0102030405060708090a0b0c0d0e0f101112131415161718')
+VALUE = 12345678
+
+CMX_ORCHARD = bytes.fromhex(
+    '02defb39c8f2e1ecc945189373cf2a8e21d4e154398efa1621d5fb989e1deb36')
+CMX_IRONWOOD = bytes.fromhex(
+    '896ee345d8b0409872172537666a482409661a22ad77c09896a3e71765f18633')
+
+# OrchardReceiverToUnifiedAddress_KnownVector. 106 characters -- three full
+# body rows on their own, which is the entire reason the confirm needs two
+# screens instead of one.
+EXPECTED_UA = ('u1ut4h93zg5670tyqss7tneru3t7h6dk62r9hhyxyrpv3nwwe9dnyj5l0ruwygf'
+               '74gp5f3zklj5xly4h8h54un3asugt9mn6gwfqsq3wq7')
+
+ORCHARD_TX = dict(tx_version=5, version_group_id=0x26A7270A, branch_id=0x5437F330)
+IRONWOOD_TX = dict(tx_version=6, version_group_id=0xD884B698, branch_id=0x37A5165B)
+
+ANCHOR = b'\x13' * 32
+FLAGS = 3
+
+
+def _b2b(person, data):
+    return hashlib.blake2b(data, digest_size=32, person=person).digest()
+
+
+def header_digest(tx_version, version_group_id, branch_id, lock_time, expiry):
+    """BLAKE2b-256('ZTxIdHeadersHash', 20-byte LE header). zcash.c:840-857."""
+    header = struct.pack('<IIIII', tx_version | 0x80000000, version_group_id,
+                         branch_id, lock_time, expiry)
+    return _b2b(b'ZTxIdHeadersHash', header)
+
+
+def bundle_digest(actions, ironwood, tx_version,
+                  flags=FLAGS, value_balance=0, anchor=ANCHOR):
+    """The shielded bundle digest the device recomputes. fsm_msg_zcash.h:1116-1189.
+
+    The anchor is folded in only for pre-v6 transactions, and that is keyed on
+    tx_version rather than on the pool.
+    """
+    if ironwood:
+        pc, pm, pn, pb = (b'ZTxIdIrnActCH_v6', b'ZTxIdIrnActMH_v6',
+                          b'ZTxIdIrnActNH_v6', b'ZTxIdIronwd_H_v6')
+    else:
+        pc, pm, pn, pb = (b'ZTxIdOrcActCHash', b'ZTxIdOrcActMHash',
+                          b'ZTxIdOrcActNHash', b'ZTxIdOrchardHash')
+
+    compact = _b2b(pc, b''.join(
+        a['nullifier'] + a['cmx'] + a['epk'] + a['enc_compact'] for a in actions))
+    memos = _b2b(pm, b''.join(a['enc_memo'] for a in actions))
+    noncompact = _b2b(pn, b''.join(
+        a['cv_net'] + a['rk'] + a['enc_noncompact'] + a['out_ciphertext']
+        for a in actions))
+
+    body = compact + memos + noncompact + bytes([flags]) + struct.pack('<q', value_balance)
+    if tx_version != 6:
+        body += anchor
+    return _b2b(pb, body)
+
+
+def note_action(cmx, recipient=RECIPIENT, value=VALUE, rseed=RSEED):
+    """One action carrying real output metadata.
+
+    Every field is size-checked by the firmware (fsm_msg_zcash.h:1068-1088) and
+    is_spend must be present even when false. is_spend=False keeps this focused
+    on the confirm screens: no RedPallas signature is emitted, so the test does
+    not need an rk consistent with the device's spend authorizing key.
+    """
+    return {
+        'alpha': b'\x01' * 32,
+        'nullifier': RHO,          # the firmware feeds this in as rho
+        'cmx': cmx,
+        'epk': b'\x02' * 32,
+        'enc_compact': b'\x03' * 52,
+        'enc_memo': b'\x04' * 512,
+        'enc_noncompact': b'\x05' * 16,
+        'cv_net': b'\x06' * 32,
+        'rk': b'\x07' * 32,
+        'out_ciphertext': b'\x08' * 80,
+        'is_spend': False,
+        'value': value,
+        'recipient': recipient,
+        'rseed': rseed,
+    }
+
+
+def sign_kwargs(actions, ironwood=False, **overrides):
+    """A shielded-only request the firmware will actually accept.
+
+    Two gates the offline fixtures do not satisfy: the header digest is
+    recomputed and compared (fsm_msg_zcash.h:677-685), and for a shielded-only
+    transaction the verified fee reduces to orchard_value_balance, which must
+    equal the declared fee (fsm_msg_zcash.h:281-326). Both are zero here.
+    """
+    tx = dict(IRONWOOD_TX if ironwood else ORCHARD_TX)
+    tx.update({k: overrides.pop(k) for k in list(overrides)
+               if k in ('tx_version', 'version_group_id', 'branch_id')})
+    lock_time, expiry = 0, 0
+
+    digest = bundle_digest(actions, ironwood, tx['tx_version'])
+    kwargs = {
+        'address_n': ADDRESS_N,
+        'actions': actions,
+        'account': 0,
+        'total_amount': VALUE,
+        'fee': 0,
+        'lock_time': lock_time,
+        'expiry_height': expiry,
+        'orchard_flags': FLAGS,
+        'orchard_value_balance': 0,
+        'orchard_anchor': ANCHOR,
+        'header_digest': header_digest(tx['tx_version'], tx['version_group_id'],
+                                       tx['branch_id'], lock_time, expiry),
+        'orchard_digest': digest,
+    }
+    kwargs.update(tx)
+    if ironwood:
+        kwargs['shielded_pool'] = zcash_proto.ZCASH_SHIELDED_POOL_IRONWOOD
+        kwargs['ironwood_digest'] = digest
+        # orchard_digest is still required to be present and 32 bytes, but for
+        # Ironwood it is the ironwood_digest that is verified against the
+        # actions; this one only feeds the locally derived sighash.
+        kwargs['orchard_digest'] = b'\x00' * 32
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _lit_pixels(layout):
+    """Count set pixels in a raw 2048-byte OLED framebuffer.
+
+    read_layout returns the framebuffer, not text -- there is no glyph decoder
+    anywhere in this repo -- so screen assertions here are structural: a screen
+    that renders nothing, or two screens that render identically, are both
+    detectable without OCR.
+    """
+    total = 0
+    for b in layout:
+        if isinstance(b, str):
+            b = ord(b)
+        total += bin(b).count('1')
+    return total
+
+
+class TestZcashShieldedSigningDevice(common.KeepKeyTest):
+
+    def setUp(self):
+        super(TestZcashShieldedSigningDevice, self).setUp()
+        self.requires_firmware("7.15.0")
+        self.requires_fullFeature()
+        self.requires_message("ZcashSignPCZT")
+        self.setup_mnemonic_allallall()
+
+    def _capture_button_screens(self):
+        """Record the framebuffer at each ButtonRequest, before it is acked."""
+        screens = []
+        original = self.client.callback_ButtonRequest
+
+        def capture(msg):
+            screens.append((msg.code, self.client.debug.read_layout()))
+            return original(msg)
+
+        self.client.callback_ButtonRequest = capture
+        return screens
+
+    def test_shielded_output_review_is_two_screens(self):
+        """The amount and the full address must each get a screen of their own.
+
+        A unified address is 106 characters, which is three full body rows. The
+        standard notification body is three rows and draw_string simply stops
+        emitting once a character will not fit -- no scroll, no pagination, no
+        indication. So a single confirm holding the question, the address and
+        the amount rendered the question plus the first 76 address characters
+        and silently dropped the rest along with the entire amount line.
+
+        Two ConfirmOutput requests per action is therefore the assertion that
+        matters: one screen cannot hold both, and collapsing them back into one
+        reintroduces exactly the defect.
+        """
+        actions = [note_action(CMX_ORCHARD)]
+        screens = self._capture_button_screens()
+
+        result = self.client.zcash_sign_pczt(**sign_kwargs(actions))
+
+        self.assertIsInstance(result, zcash_proto.ZcashSignedPCZT)
+        self.assertEqual(len(result.signatures), 0)  # no is_spend action
+
+        outputs = [(code, layout) for code, layout in screens
+                   if code == proto_types.ButtonRequest_ConfirmOutput]
+        # KeepKeyTest.assertEqual takes no message argument (common.py:114).
+        self.assertTrue(
+            len(outputs) == 2,
+            "expected an amount screen and an address screen per shielded "
+            "output; got %d ConfirmOutput screen(s). One screen cannot fit a "
+            "106-character unified address plus an amount line."
+            % len(outputs))
+
+        amount_screen, address_screen = outputs[0][1], outputs[1][1]
+        self.assertNotEqual(bytes(amount_screen), bytes(address_screen),
+                            "the two review screens rendered identically")
+        for name, layout in (('amount', amount_screen), ('address', address_screen)):
+            self.assertEqual(len(layout), 2048)
+            self.assertGreater(_lit_pixels(layout), 200,
+                               "%s screen rendered (near-)blank" % name)
+
+        # The address occupies three dense rows; the amount line is one short
+        # row. If the address screen were truncated to the amount screen's
+        # content this ordering would not hold.
+        self.assertGreater(_lit_pixels(address_screen), _lit_pixels(amount_screen))
+
+    def test_note_commitment_binds_the_recipient(self):
+        """Flipping one recipient bit must break the commitment check.
+
+        This is what stops a host from showing one recipient and committing to
+        another: the device recomputes cmx from recipient, value, rho and rseed
+        and compares it to the supplied commitment.
+        """
+        tampered = bytearray(RECIPIENT)
+        tampered[0] ^= 0x01
+        actions = [note_action(CMX_ORCHARD, recipient=bytes(tampered))]
+
+        with self.assertRaises(Exception) as caught:
+            self.client.zcash_sign_pczt(**sign_kwargs(actions))
+        self.assertIn('commitment mismatch', str(caught.exception))
+
+    def test_pool_selection_is_honoured(self):
+        """The same note commits differently in each pool.
+
+        Orchard and Ironwood derive a different cmx from identical inputs, so
+        offering the Orchard commitment while declaring the Ironwood pool must
+        be rejected. If the device ignored shielded_pool this would pass.
+        """
+        actions = [note_action(CMX_ORCHARD)]
+
+        with self.assertRaises(Exception) as caught:
+            self.client.zcash_sign_pczt(**sign_kwargs(actions, ironwood=True))
+        self.assertIn('commitment mismatch', str(caught.exception))
+
+    def test_ironwood_note_is_accepted(self):
+        """The Ironwood commitment for that same note is accepted.
+
+        The positive half of the pool test -- together they prove the branch is
+        selected by shielded_pool rather than one path serving both.
+        """
+        actions = [note_action(CMX_IRONWOOD)]
+        screens = self._capture_button_screens()
+
+        result = self.client.zcash_sign_pczt(**sign_kwargs(actions, ironwood=True))
+
+        self.assertIsInstance(result, zcash_proto.ZcashSignedPCZT)
+        outputs = [c for c, _ in screens
+                   if c == proto_types.ButtonRequest_ConfirmOutput]
+        self.assertTrue(len(outputs) == 2,
+                        "expected 2 ConfirmOutput screens, got %d" % len(outputs))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_msg_zcash_sign_pczt_device.py
+++ b/tests/test_msg_zcash_sign_pczt_device.py
@@ -21,6 +21,7 @@ actually honours shielded_pool instead of ignoring it.
 
 import hashlib
 import struct
+import time
 import unittest
 
 import common
@@ -182,6 +183,11 @@ def _lit_pixels(layout):
     return total
 
 
+# Matches client.SCREENSHOT_SETTLE_SECONDS; the emulator needs a moment to
+# finish drawing after ButtonRequest before read_layout() is meaningful.
+BUTTON_RENDER_SETTLE_SECONDS = 0.5
+
+
 class TestZcashShieldedSigningDevice(common.KeepKeyTest):
 
     def setUp(self):
@@ -197,6 +203,17 @@ class TestZcashShieldedSigningDevice(common.KeepKeyTest):
         original = self.client.callback_ButtonRequest
 
         def capture(msg):
+            # The firmware emits ButtonRequest immediately BEFORE drawing the
+            # confirmation, so the framebuffer must be allowed to settle first.
+            # original(msg) does contain that delay, but it runs after this read
+            # and then presses the button -- so reading before it captures a
+            # partially drawn (or previous) screen, and reading after it captures
+            # the NEXT one. Settle here instead.
+            #
+            # Unconditional, unlike client.callback_ButtonRequest's SCREENSHOT-only
+            # sleep: these are structural assertions, not screenshot evidence, so
+            # they need a settled layout on every run.
+            time.sleep(BUTTON_RENDER_SETTLE_SECONDS)
             screens.append((msg.code, self.client.debug.read_layout()))
             return original(msg)
 


### PR DESCRIPTION
Brings `reconcile/upstream-sync` up to the python-keepkey commit firmware
rc29 is actually built against, and adds the one regression test that was
missing for the 7.15 EIP-1559 fix.

## Why this exists

SOP is that before a signed release the firmware pins the **canonical branch of
the single open PR into master** — not master, and not a fork branch. Auditing
rc29 against that standard:

| submodule | rc29 pin | on its canonical branch? |
|---|---|---|
| `deps/device-protocol` | `cf308fd` | yes — `upstream/up/release-protocol` |
| `deps/python-keepkey` | `417a613` | **no** |

`git rev-list --left-right --count reconcile/upstream-sync...417a613` returned
`0 5`: this branch had **zero** commits the pin lacked, and the pin carried
**five** this branch had never seen. Lineage was fine — the canonical branch is
fully contained — but rc29 sat five commits past what was under review, and
those five were only reachable from a fork branch
(`BitHighlander:fix/catalog-pin-kdf-rename`).

The five, now included here:

```
b44f1b3 test(reset): display_random is accepted and ignored
74768b0 report: catalog the 7.15 seed-generation evidence and state the report's scope
5761392 report: say which Zcash shielded tests never touch a device
3bbf996 test(zcash): sign a shielded transaction on an actual device
417a613 fix(report): K8 named a storage test that no longer exists
```

They touch only `scripts/generate-test-report.py`,
`tests/test_msg_resetdevice.py`, and `tests/test_msg_zcash_sign_pczt_device.py`
— **no `keepkeylib/`**. That distinction matters: firmware CMake executes
`deps/python-keepkey/keepkeylib/eth/*.py` at build time, so python-keepkey can
change the firmware binary. These do not. **rc29's binary is unaffected.**

What was affected is the evidence trail: three of the five change the zoo report
generator, including one whose entire point is *"say which Zcash shielded tests
never touch a device."* The binary is clean; the report describing it was
produced by tooling outside the canonical PR.

## New in this PR

`test_ethereum_eip_1559_multibyte_chain_id` — firmware `ed6db167` ("EIP-1559
chainId hashing wrong for multi-byte chain IDs") shipped with no test at a chain
id that reproduces it. Every EIP-1559 case in that file uses `chain_id` 1 or 3,
both single-byte, so the bug had no coverage in the file that tests the feature.

A golden `r`/`s` would need a device run, so it is a differential instead: sign
one identical transaction under two chain ids the **buggy** firmware cannot
distinguish.

```
8453 = 0x2105   low byte 0x05, two-byte value
4357 = 0x1105   low byte 0x05, two-byte value
```

Same low byte **and** same RLP length header, so the broken code hashes a
byte-identical pre-image for both; signing is deterministic (RFC 6979), so it
returns the same signature twice and the assertion fails. Correct firmware
hashes `0x21 0x05` vs `0x11 0x05`. No golden value and no new dependencies —
the repo has `ecdsa` but no keccak, so recovering the signer address was not
available.

Comparing against `chain_id=5` would **not** work: the RLP length was always
derived from the full value, so the buggy pre-image for 8453 is malformed rather
than equal to a well-formed single-byte encoding. The twin has to match on both
low byte and byte-width.

Version-gated to `7.15.0`, so it SKIPs rather than fails on firmware predating
the fix. Worth confirming in CI that it **ran** rather than skipped — a green
tick alone does not distinguish them.

## Reviewer note

Vault cannot reach the EIP-1559 path on affected chains at all: plain sends are
unconditionally legacy (`txbuilder/evm.ts:205`) and swaps force legacy for
`chainId >= 256` (`eip1559Ok = chainId < 256`). The vault REST API does pass
caller-supplied `maxFeePerGas` straight through, and the browser extension
builds type-2 with no chainId guard — which is why the failures only ever
appeared there.

Merges as a fast-forward (`0	8` against this base).

## Review round 1 — all four technical findings fixed (2cf5edc)

1. **Version gate removed real coverage.** Correct, and my regression. The gate skipped the *whole* of `test_reset_device_pin`/`test_failed_pin` on the 7.10 emulator — PIN entry, `EntropyRequest`/`Ack`, mnemonic derivation — to silence one assertion. Now branches on version: pre-7.15 acks the Internal Entropy `ButtonRequest` that legitimately still exists, both paths converge on `PinMatrixRequest`, everything downstream keeps running everywhere.
2. **Z17 contradicted Z22.** Correct. Scoped the claim to that module and pointed at Z22.
3. **Skips reported as executed.** Correct and the most consequential. `ran` counted skips; this very run was 613 collected / 252 skipped, a 41% overstatement. Now tracks `skipped` separately, says *collected*, and states inline that a skip is not evidence a feature works.
4. **OLED capture before settle.** Correct. Settle moved inside the wrapper before `read_layout()` — reading after would be worse, since the original callback presses the button and advances the screen. Made unconditional because these are structural assertions, not screenshot evidence.
5. **Stale `0 6`.** Updated above rather than squashed — the review history is worth keeping on a reconcile PR whose whole purpose is that these commits were never reviewed.

**Also worth flagging from this round:** `test_ethereum_eip_1559_multibyte_chain_id` **SKIPPED** in CI (emulator predates 7.15.0) while `test_ethereum_eip_1559` passed beside it. It is inert until the CI emulator moves up — which is exactly the condition finding 3 now makes visible in the report instead of hiding.
