### PR TITLE
test(recovery): gate per-word BIP-39 validation at 7.15.1, as documented

### DIFF
--- a/tests/test_msg_recoverydevice_cipher.py
+++ b/tests/test_msg_recoverydevice_cipher.py
@@ -174,7 +174,7 @@ class TestDeviceRecovery(common.KeepKeyTest):
         BIP-39 wordlist must return Failure immediately.
         Requires firmware 7.15.1+ (per-word validation).
         """
-        self.requires_firmware("7.15.0")
+        self.requires_firmware("7.15.1")
         ret = self.client.call_raw(proto.RecoveryDevice(word_count=12,
                                    passphrase_protection=False,
                                    pin_protection=False,


### PR DESCRIPTION
The test's own docstring says the feature it exercises requires firmware
7.15.1+, but the gate admitted 7.15.0. Any 7.15.0 build therefore runs a
test for behaviour that release is not expected to have: entering a word
outside the BIP-39 wordlist returns a CharacterRequest for the next word
rather than a Failure, and the assertion fails.

No behaviour change -- the gate now matches the docstring beside it.