### PR TITLE
Merge the 7.15 security test work into reconcile/upstream-sync

### DIFF
--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -2291,6 +2291,15 @@ SECTIONS = [
           'notes, reuse an approved action alpha so rk is byte-identical, and the single '
           'RedPallas signature the device emits verifies in BOTH bundles.',
           []),
+         ('Z27', 'test_multisig',
+          'test_oversized_signature_is_rejected',
+          'Oversized multisig signature refused (ON DEVICE)',
+          'MultisigRedeemScriptType.signatures is declared max_size:73 but a DER ECDSA signature '
+          'is at most 72. The witness serializer appended the sighash byte AT signatures[i].size, '
+          'so 73 wrote one past the end of bytes[73] -- onto signatures[i+1].size for i < 14, '
+          'which can revive a slot the host left empty and change the witness stack after the '
+          'user reviewed it. A declared max_size is a decoder bound, not a runtime one.',
+          []),
      ]),
 
     ('D', 'BIP-85 Child Derivation', '7.14.0',

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -2281,6 +2281,16 @@ SECTIONS = [
           'they prove the pool branch is selected by shielded_pool rather than one path serving '
           'both.',
           []),
+         ('Z26', 'test_msg_zcash_sign_pczt_device',
+          'test_ironwood_rejects_a_non_empty_orchard_bundle',
+          'v6 refuses an unverified Orchard bundle (ON DEVICE)',
+          'A v6 transaction streams and verifies only its Ironwood actions, so its Orchard '
+          'bundle must be the ZIP-244 empty-bundle digest. Any other value describes a bundle '
+          'the device never inspected but still commits to in the sighash it signs. That was '
+          'exploitable: point orchard_digest at a real bundle spending one of this seed '
+          'notes, reuse an approved action alpha so rk is byte-identical, and the single '
+          'RedPallas signature the device emits verifies in BOTH bundles.',
+          []),
      ]),
 
     ('D', 'BIP-85 Child Derivation', '7.14.0',

--- a/tests/test_msg_display_disclosure.py
+++ b/tests/test_msg_display_disclosure.py
@@ -131,6 +131,13 @@ class TestDisplayDisclosesSignedContent(common.KeepKeyTest):
     def setUp(self):
         super(TestDisplayDisclosesSignedContent, self).setUp()
         self.requires_firmware(self.MIN_FIRMWARE)
+        # The inherited setUp wipes the device. Without a seed every
+        # SignMessage below is refused with Failure_NotInitialized before
+        # confirm_bytes() is ever reached, _sign_message_screens() returns
+        # None, and _assert_distinguishable() returns without asserting -- so
+        # the whole suite passed while exercising zero display logic. Load a
+        # seed so the device actually renders the screens under test.
+        self.setup_mnemonic_nopin_nopassphrase()
 
     # ── helpers ─────────────────────────────────────────────────────────
 
@@ -165,8 +172,22 @@ class TestDisplayDisclosesSignedContent(common.KeepKeyTest):
         b = self._sign_message_screens(b_msg)
 
         if a is None or b is None:
-            # Refusing to display something it cannot show honestly is a pass.
-            return
+            # A refusal is only meaningful from an initialized device that
+            # could have signed and chose not to. On an uninitialized device
+            # every call is refused for an unrelated reason, which is what let
+            # this suite pass vacuously -- so assert the device can sign at
+            # all before treating a refusal as the honest-refusal pass.
+            self.assertTrue(
+                self.client.features.initialized,
+                "device is not initialized, so this refusal says nothing "
+                "about display disclosure -- the assertion below never ran")
+            refused = a_label if a is None else b_label
+            raise AssertionError(
+                "device refused to sign %s. Refusing to display what it "
+                "cannot show honestly is defensible, but it must be an "
+                "explicit, reviewed decision rather than a silent pass: if "
+                "this is intended, assert the refusal here by name."
+                % refused)
 
         self.assertNotEqual(
             a, b,
@@ -244,8 +265,14 @@ class TestDisplayDisclosesSignedContent(common.KeepKeyTest):
         empty tuples and the suite would pass while showing the user nothing.
         """
         screens = self._sign_message_screens(b"hello")
-        if screens is None:
-            self.skipTest("device refused to sign the control message")
+        # Do NOT skip here. This test exists to prove the rest of the file is
+        # not vacuous, so skipping itself when the device will not sign is the
+        # one failure mode it cannot be allowed to have -- that is exactly how
+        # the whole suite went green against an uninitialized device.
+        self.assertIsNotNone(
+            screens,
+            "device refused to sign the control message, so every comparison "
+            "in this file compared None against None and asserted nothing")
         self.assertGreater(
             len(screens), 0,
             "signing produced no ButtonRequest, so nothing was shown to the "

--- a/tests/test_msg_mayachain_signtx.py
+++ b/tests/test_msg_mayachain_signtx.py
@@ -9,7 +9,9 @@ from ecdsa import VerifyingKey, SECP256k1
 from ecdsa.util import sigdecode_string
 
 import keepkeylib.messages_pb2 as proto
+import keepkeylib.messages_mayachain_pb2 as mayachain_proto
 import keepkeylib.types_pb2 as proto_types
+from keepkeylib.client import CallException
 from keepkeylib.tools import parse_path
 from keepkeylib.signed_metadata import eth_sighash_legacy, keccak256
 
@@ -53,6 +55,28 @@ def recover_eth_signer(sig_r, sig_s, sig_v, digest, chain_id):
 
 
 class TestMsgMayaChainSignTx(common.KeepKeyTest):
+
+    def test_ack_rejects_send_and_deposit_together(self):
+        """An unused deposit submessage must not suppress the signed tx memo."""
+        self.requires_firmware("7.15.0")
+        self.requires_fullFeature()
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        response = self.client.call(mayachain_proto.MayachainSignTx(
+            address_n=parse_path(DEFAULT_BIP32_PATH), account_number=92,
+            chain_id="mayachain", fee_amount=3000, gas=200000,
+            memo="SWAP:BTC.BTC:bc1qreviewthismemo", sequence=3,
+            msg_count=1, testnet=False))
+        self.assertIsInstance(response, mayachain_proto.MayachainMsgRequest)
+
+        with self.assertRaises(CallException):
+            self.client.call(mayachain_proto.MayachainMsgAck(
+                send=mayachain_proto.MayachainMsgSend(
+                    to_address="maya1jvt443rvhq5h8yrna55yjysvhtju0el7mdujp3",
+                    amount=10000, denom="cacao"),
+                deposit=mayachain_proto.MayachainMsgDeposit(
+                    asset="MAYA.CACAO", amount=1, memo="unused",
+                    signer="maya1ls33ayg26kmltw7jjy55p32ghjna09zp7z4etj")))
 
     def _maya_send_digest(self, account_number, chain_id, fee, gas, memo,
                           amount, from_address, to_address, sequence):

--- a/tests/test_msg_thorchain_signtx.py
+++ b/tests/test_msg_thorchain_signtx.py
@@ -120,6 +120,28 @@ class TestThorchainClientDenom(unittest.TestCase):
 
 class TestMsgThorChainSignTx(common.KeepKeyTest):
 
+    def test_ack_rejects_send_and_deposit_together(self):
+        """An unused deposit submessage must not alter the send review flow."""
+        self.requires_fullFeature()
+        self.requires_firmware("7.15.0")
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        response = self.client.call(thorchain_proto.ThorchainSignTx(
+            address_n=parse_path(DEFAULT_BIP32_PATH), account_number=92,
+            chain_id="thorchain", fee_amount=3000, gas=200000,
+            memo="SWAP:BTC.BTC:bc1qreviewthismemo", sequence=3,
+            msg_count=1, testnet=False))
+        self.assertIsInstance(response, thorchain_proto.ThorchainMsgRequest)
+
+        with self.assertRaises(CallException):
+            self.client.call(thorchain_proto.ThorchainMsgAck(
+                send=thorchain_proto.ThorchainMsgSend(
+                    to_address="thor1jvt443rvhq5h8yrna55yjysvhtju0el7ldnwwy",
+                    amount=10000, denom="rune"),
+                deposit=thorchain_proto.ThorchainMsgDeposit(
+                    asset="THOR.RUNE", amount=1, memo="unused",
+                    signer="thor1ls33ayg26kmltw7jjy55p32ghjna09zp6z69y8")))
+
     def test_thorchain_sign_tx(self):
         self.requires_fullFeature()
         self.requires_firmware("7.0.2")

--- a/tests/test_msg_zcash_sign_pczt_device.py
+++ b/tests/test_msg_zcash_sign_pczt_device.py
@@ -168,10 +168,11 @@ def sign_kwargs(actions, ironwood=False, **overrides):
         # victim's note, reusing an approved action's alpha so the one emitted
         # RedPallas signature verified in both bundles.
         #
-        # ZIP-244 empty-bundle digest: BLAKE2b-256 of the empty string
-        # personalized "ZTxIdOrchardHash". The device now requires exactly this.
+        # ZIP-229 v6 empty-bundle digest: BLAKE2b-256 of the empty string
+        # personalized "ZTxIdOrchardH_v6". The v5/ZIP-244
+        # "ZTxIdOrchardHash" value is a different digest.
         kwargs['orchard_digest'] = bytes.fromhex(
-            '9fbe4ed13b0c08e671c11a3407d84e1117cd45028a2eee1b9feae78b48a6e2c1')
+            'a3367d2fdea2910159fc5026e9bf1fccd3e28ce5e6de46bfb71587230eea9515')
     kwargs.update(overrides)
     return kwargs
 
@@ -319,7 +320,7 @@ class TestZcashShieldedSigningDevice(common.KeepKeyTest):
         """
         actions = [note_action(CMX_IRONWOOD)]
         kwargs = sign_kwargs(actions, ironwood=True)
-        # Anything but the ZIP-244 empty-bundle digest must be refused.
+        # Anything but the ZIP-229 v6 empty-bundle digest must be refused.
         kwargs['orchard_digest'] = bytes([0x11]) * 32
 
         with self.assertRaises(Exception) as caught:

--- a/tests/test_msg_zcash_sign_pczt_device.py
+++ b/tests/test_msg_zcash_sign_pczt_device.py
@@ -159,10 +159,19 @@ def sign_kwargs(actions, ironwood=False, **overrides):
     if ironwood:
         kwargs['shielded_pool'] = zcash_proto.ZCASH_SHIELDED_POOL_IRONWOOD
         kwargs['ironwood_digest'] = digest
-        # orchard_digest is still required to be present and 32 bytes, but for
-        # Ironwood it is the ironwood_digest that is verified against the
-        # actions; this one only feeds the locally derived sighash.
-        kwargs['orchard_digest'] = b'\x00' * 32
+        # A v6 transaction streams and verifies only its Ironwood actions, so
+        # its Orchard bundle must be EMPTY -- and provably so. This used to be
+        # b'\x00' * 32, arbitrary filler, with a comment noting that the field
+        # "only feeds the locally derived sighash". That was the bug: the
+        # device signed a sighash committing to an Orchard bundle it never
+        # inspected, and a host could point it at a real bundle spending the
+        # victim's note, reusing an approved action's alpha so the one emitted
+        # RedPallas signature verified in both bundles.
+        #
+        # ZIP-244 empty-bundle digest: BLAKE2b-256 of the empty string
+        # personalized "ZTxIdOrchardHash". The device now requires exactly this.
+        kwargs['orchard_digest'] = bytes.fromhex(
+            '9fbe4ed13b0c08e671c11a3407d84e1117cd45028a2eee1b9feae78b48a6e2c1')
     kwargs.update(overrides)
     return kwargs
 
@@ -292,6 +301,30 @@ class TestZcashShieldedSigningDevice(common.KeepKeyTest):
         with self.assertRaises(Exception) as caught:
             self.client.zcash_sign_pczt(**sign_kwargs(actions, ironwood=True))
         self.assertIn('commitment mismatch', str(caught.exception))
+
+    def test_ironwood_rejects_a_non_empty_orchard_bundle(self):
+        """A v6 transaction may not carry an unverified Orchard bundle.
+
+        The device streams and verifies only the ACTIVE pool's actions. On the
+        Ironwood path that is the Ironwood bundle, so an orchard_digest other
+        than the empty-bundle value describes a bundle the device never
+        inspected yet still commits to in the sighash it signs.
+
+        That was exploitable, not merely untidy: point orchard_digest at a real
+        Orchard bundle spending one of this seed's notes, reuse the alpha of an
+        approved Ironwood action so rk is byte-identical, and the single
+        RedPallas signature the device emits verifies in BOTH bundles, because
+        verification is [s]G = R + [H(R||rk||M)]rk and rk and M are shared. The
+        Orchard bundle's valueBalance never enters the device's fee check.
+        """
+        actions = [note_action(CMX_IRONWOOD)]
+        kwargs = sign_kwargs(actions, ironwood=True)
+        # Anything but the ZIP-244 empty-bundle digest must be refused.
+        kwargs['orchard_digest'] = bytes([0x11]) * 32
+
+        with self.assertRaises(Exception) as caught:
+            self.client.zcash_sign_pczt(**kwargs)
+        self.assertIn('empty Orchard bundle', str(caught.exception))
 
     def test_ironwood_note_is_accepted(self):
         """The Ironwood commitment for that same note is accepted.

--- a/tests/test_multisig.py
+++ b/tests/test_multisig.py
@@ -240,5 +240,49 @@ class TestMultisig(common.KeepKeyTest):
             self.assertRaises(CallException, self.client.sign_tx, 'Bitcoin', [inp1, ], [out1, ])
 
 
+    def test_oversized_signature_is_rejected(self):
+        """A multisig signature longer than a DER ECDSA signature is refused.
+
+        MultisigRedeemScriptType.signatures is declared max_size:73, so the
+        decoder accepts 73 bytes -- but a DER-encoded ECDSA signature is at
+        most 72 (0x30 len, then two 0x02-tagged integers of at most 33 bytes).
+        The witness serializer used to append the sighash byte AT
+        signatures[i].size, so a 73-byte value wrote one past the end of
+        bytes[73]: onto signatures[i+1].size for i < 14, which can revive a
+        slot the host left empty and change the witness stack after the user
+        reviewed it, or onto has_m at i == 14.
+
+        The declared max_size is a decoder bound, never a runtime one. This
+        asserts the device applies the real one.
+        """
+        self.setup_mnemonic_nopin_nopassphrase()
+
+        node = ckd_public.deserialize('xpub661MyMwAqRbcF1zGijBb2K6x9YiJPh58xpcCeLvTxMX6spkY3PcpJ4ABcCyWfskq5DDxM3e6Ez5ePCqG5bnPUXR4wL8TZWyoDaUdiWW7bKy')
+
+        multisig = proto_types.MultisigRedeemScriptType(
+                            pubkeys=[proto_types.HDNodePathType(node=node, address_n=[1]),
+                                     proto_types.HDNodePathType(node=node, address_n=[2]),
+                                     proto_types.HDNodePathType(node=node, address_n=[3])],
+                            # 73 bytes: one more than any real DER signature,
+                            # and exactly the value that overflowed the write.
+                            signatures=[b'\x30' * 73, b'', b''],
+                            m=2,
+                            )
+
+        inp1 = proto_types.TxInputType(address_n=[1],
+                             prev_hash=binascii.unhexlify('c6091adf4c0c23982a35899a6e58ae11e703eacd7954f588ed4b9cdefc4dba52'),
+                             prev_index=1,
+                             script_type=proto_types.SPENDMULTISIG,
+                             multisig=multisig,
+                             )
+
+        out1 = proto_types.TxOutputType(address='12iyMbUb4R2K3gre4dHSrbu5azG5KaqVss',
+                              amount=100000,
+                              script_type=proto_types.PAYTOADDRESS)
+
+        with self.client:
+            self.assertRaises(CallException, self.client.sign_tx, 'Bitcoin', [inp1, ], [out1, ])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Two live pyk lines had diverged with **no superset between them**:

| branch | commits the other lacked | content |
|---|---|---|
| `reconcile/upstream-sync` | 17 | CI gates, Aave V3 fixture correction, token dedup on `(chain_id, address)`, emulator/udp fixes |
| `release/7.15-audit-fixes` | 4 | the 7.15 security test work |

Both root at `44d82efe7`, so this merges cleanly — no conflicts.

## The four security commits

- **`5f872cc`** — the display-disclosure suite was passing **vacuously**. `setUp` wiped the device and never loaded a seed, so every `SignMessage` was refused with `Failure_NotInitialized` before `confirm_bytes()` was reached; the helper returned `None` and `_assert_distinguishable()` returned before its `assertNotEqual` ever ran. Four tests reported PASS having exercised **zero** display logic, and the fifth — written specifically to catch this — skipped itself on the same condition.
- **`34a1c6c`** — the v6 Ironwood fixture passed `b'\x00'*32` as `orchard_digest`, with a comment explaining the field "only feeds the locally derived sighash". That comment described the **vulnerability** as if it were the design: the device signed a sighash committing to an Orchard bundle it never inspected. Now uses the ZIP-244 empty-bundle digest, which the firmware requires.
- **`b91d87b`** — Z27: an oversized multisig signature must be refused (the wire field is `max_size:73`, a DER ECDSA signature is at most 72, and the witness serializer wrote the sighash byte one past the end).
- **`3305b80`** — ZIP-229 and ambiguous message acks.

## Why this matters for the pins

`keepkey-firmware` alpha declares it tracks `reconcile/upstream-sync`, but its actual pin (`999e776a6`) lives only on `pre-squash-197-backup` and shares **no merge-base** with the live lineage. Advancing that pin to a branch that lacked the security tests would have shipped the firmware fixes without the tests that prove them.

After this merge, `reconcile/upstream-sync` carries both lines and the firmware pins can point at it honestly.

## Verified after merging

- Both sides' content present (Ironwood/multisig/disclosure tests **and** the Aave V3 fixture, token dedup)
- Every changed file parses
- **Z26 and Z27 are registered in the report catalog**, so they sit inside the CI filter and actually run rather than being inert — an unregistered test would never execute