### PR TITLE
test(ethereum): require advanced mode for MakerDAO calldata

### DIFF
--- a/tests/test_msg_ethereum_makerdao.py
+++ b/tests/test_msg_ethereum_makerdao.py
@@ -30,6 +30,8 @@ class TestMsgEthereumtxMakerDAO(common.KeepKeyTest):
     def test_generate(self):
         self.requires_fullFeature()
         self.setup_mnemonic_nopin_nopassphrase()
+        # MakerDAO calldata now follows the generic blind-signing path.
+        self.client.apply_policy("AdvancedMode", 1)
 
         sig_v, sig_r, sig_s = self.client.ethereum_sign_tx(
             n=[2147483692,2147483708,2147483648,0,0],
@@ -50,6 +52,8 @@ class TestMsgEthereumtxMakerDAO(common.KeepKeyTest):
     def test_deposit(self):
         self.requires_fullFeature()
         self.setup_mnemonic_nopin_nopassphrase()
+        # MakerDAO calldata now follows the generic blind-signing path.
+        self.client.apply_policy("AdvancedMode", 1)
 
         sig_v, sig_r, sig_s = self.client.ethereum_sign_tx(
             n=[2147483692,2147483708,2147483648,0,0],
@@ -71,6 +75,8 @@ class TestMsgEthereumtxMakerDAO(common.KeepKeyTest):
     def test_close(self):
         self.requires_fullFeature()
         self.setup_mnemonic_nopin_nopassphrase()
+        # MakerDAO calldata now follows the generic blind-signing path.
+        self.client.apply_policy("AdvancedMode", 1)
 
         sig_v, sig_r, sig_s = self.client.ethereum_sign_tx(
             n=[2147483692,2147483708,2147483648,0,0],
@@ -92,6 +98,8 @@ class TestMsgEthereumtxMakerDAO(common.KeepKeyTest):
     def test_free(self):
         self.requires_fullFeature()
         self.setup_mnemonic_nopin_nopassphrase()
+        # MakerDAO calldata now follows the generic blind-signing path.
+        self.client.apply_policy("AdvancedMode", 1)
 
         sig_v, sig_r, sig_s = self.client.ethereum_sign_tx(
             n=[2147483692,2147483708,2147483648,0,0],
@@ -111,4 +119,3 @@ class TestMsgEthereumtxMakerDAO(common.KeepKeyTest):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_msg_solana_signtx.py
+++ b/tests/test_msg_solana_signtx.py
@@ -277,7 +277,7 @@ class TestMsgSolanaSignTx(common.KeepKeyTest):
         with pytest.raises(CallException) as exc:
             self.client.call(messages.SolanaSignTx(
                 address_n=parse_path("m/44'/501'/0'/0'"), raw_tx=raw_tx))
-        self.assertIn("policy", str(exc.value))
+        self.assertIn("AdvancedMode", str(exc.value))
 
     def test_solana_sign_token_approve(self):
         """Unchecked SPL Approve is opaque because no mint is signed."""


### PR DESCRIPTION
## Summary

- opt the four legacy MakerDAO signing vectors into AdvancedMode
- exercise the generic full-calldata review path used after removal of the specialized firmware decoder
- retain the existing deterministic signature assertions

## Why

keepkey-firmware PR #473 deliberately removes legacy MakerDAO semantic clear-signing. The old integration tests attempted contract-data signing without the required blind-signing opt-in, causing the firmware release PR integration job to fail closed as intended.

## Validation

- Python syntax check passed
- offline transaction fixture manifest check passed
- git diff whitespace check passed

This PR targets the active 7.14.2 companion-test branch so the firmware release child PR can pin the combined test head without changing unrelated default-branch behavior.